### PR TITLE
Аттестация 2. Не стартовал сервер

### DIFF
--- a/attestation_2/server/src/logger/logger.js
+++ b/attestation_2/server/src/logger/logger.js
@@ -1,4 +1,11 @@
+// import { existsSync } from 'fs';
+const fs = require('fs');
 const context = require('request-context');
+
+if (!fs.existsSync('./logs')) {
+  console.log('Не существует каталога logs');
+  fs.mkdirSync('./logs');
+}
 
 const options = {
   logDirectory: './logs', // Директория для хранения логгов (должна существовать)


### PR DESCRIPTION
Аттестация 2. Не стартовал сервер, потому как отсутствовал каталог "logs". Исправил. Теперь буду знать, что пустые каталоги не пушатся